### PR TITLE
Bug fix for large cloud uploads

### DIFF
--- a/HousingPos/Gui/ConfigurationWindow.cs
+++ b/HousingPos/Gui/ConfigurationWindow.cs
@@ -954,9 +954,12 @@ namespace HousingPos.Gui
                                 string res = posttask.Result;
                                 Plugin.Log(res);
                             }
-                            catch (Exception e)
+                            catch (AggregateException e)
                             {
-                                Plugin.LogError($"Error while Postdata: {e.Message}", e.ToString());
+                                foreach (var errInner in e.InnerExceptions)
+                                {
+                                    Plugin.LogError($"Error while Postdata: {errInner.Message}", e.ToString()); //this will call ToString() on the inner execption and get you message, stacktrace and you could perhaps drill down further into the inner exception of it if necessary 
+                                }
                                 CanUpload = true;
                             }
                         });

--- a/HousingPos/Objects/HttpPost.cs
+++ b/HousingPos/Objects/HttpPost.cs
@@ -39,16 +39,18 @@ namespace HousingPos.Objects
                 return "You Can't Upload An Empty List.";
             HttpClient httpClient = new HttpClient();
             var UserHash = GetMD5(UserId, Md5Salt);
-            var values = new Dictionary<string, string>
+            var values = new
             {
-                {"LocationId", LocationId.ToString()},
-                {"UploadName", UploadName },
-                {"Items", str },
-                {"Tags", tags },
-                {"Uploader", Uploader },
-                {"UserId",UserHash }
+                LocationId = LocationId.ToString(),
+                UploadName = UploadName,
+                Items = str,
+                Tags = tags ,
+                Uploader = Uploader,
+                UserId = UserHash
             };
-            HttpContent data = new FormUrlEncodedContent(values);
+            var stringPayload = JsonConvert.SerializeObject(values);
+            var data = new StringContent(stringPayload, Encoding.UTF8, "application/json");
+
             HttpResponseMessage response = await httpClient.PostAsync(Uri + "/index.php", data);
             response.EnsureSuccessStatusCode();
             string resultStr = await response.Content.ReadAsStringAsync().WithTimeout(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
Altered exception logging to provide more information - Previously was only receiving "One Or More Errors Occurred"

After this change received the following error.
![error-after-alter](https://user-images.githubusercontent.com/10588509/116325688-50121b00-a79d-11eb-8777-02f502e75a44.png)

Altered post method to fix upload error due to the URI having a max length of 2083.
This broke uploads that had many items E.G Large Houses over 300 items placed and some Med Houses; if there was extra data on most items, like different colors
Now all data is converted into a JSON string before being posted. this avoids the character limit
Minor change required for server (index.php) as well.